### PR TITLE
Create camerav2_410x308.yaml

### DIFF
--- a/gpg_bran/camera_info/camerav2_410x308.yaml
+++ b/gpg_bran/camera_info/camerav2_410x308.yaml
@@ -1,0 +1,20 @@
+image_width: 410
+image_height: 308
+camera_name: camerav2_410x308
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [322.0704122808738, 0, 199.2680620421962, 0, 320.8673986158544, 155.2533082600705, 0, 0, 1]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [0.1639958233797625, -0.271840030972792, 0.001055841660100477, -0.00166555973740089, 0]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1, 0, 0, 0, 1, 0, 0, 0, 1]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [329.2483825683594, 0, 198.4101510452074, 0, 0, 329.1044006347656, 155.5057121208347, 0, 0, 0, 1, 0]


### PR DESCRIPTION
In order to implement raspicam_30fps.launch it is required to have the new camera info .yaml file in camera_info