### PR TITLE
Create raspicam_30fps.launch

### DIFF
--- a/gpg_bran/launch/raspicam_30fps.launch
+++ b/gpg_bran/launch/raspicam_30fps.launch
@@ -1,0 +1,19 @@
+<launch>
+  <node pkg="raspicam_node" type="raspicam_node" name="raspicam_node" output="screen">
+    <param name="camera_info_url" value="package://gpg_bran/camera_info/camerav2_410x308.yaml"/>
+    <param name="camera_name" value="camerav2_410x308"/>
+    <param name="camera_frame_id" value="camera"/>
+    <param name="enable_raw" value="false"/>
+    <param name="width" value="410"/>
+    <param name="height" value="308"/>
+    <param name="framerate" value="30"/>
+    <param name="enable_imv" value="false"/>
+    <param name="exposure_mode" value="antishake"/>
+    <param name="shutter_speed" value="0"/>
+    <param name="private_topics" value="true"/>
+
+  </node>
+
+  <node pkg="tf" type="static_transform_publisher" name="base_link_to_camera" args="0.0 0.0 0.0  0.0 0.0 0.0   /base_scan /camera 40" />
+
+</launch>


### PR DESCRIPTION
Launches the camera image publishing node for the raspberry pi camera. The CompressedImage ROS message is published at 30 frames per second with a resolution of 410 by 308. A raw image is not available due to the decreased processing speed.